### PR TITLE
Create default template for pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,5 +41,3 @@ plugins:
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
-
-port: 5500

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Computer Programming | CPTC</title>
+</head>
+<body>
+    <header>
+
+    </header>
+    <main>
+        {{ content }}
+    </main>
+    <footer>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Document</title>
-</head>
-<body>
-    <h1>CPW Program Site</h1>
-</body>
-</html>
+---
+layout: default
+---
+
+<p>
+    Welcome to Computer Programming
+</p>


### PR DESCRIPTION
Closes #1 
Jekyll template is being used to reduce code redundancy across pages and give the website a consistent them. Currently the theme is just a boilerplate skeleton. No styling/nav/etc is present yet